### PR TITLE
Remove console.log() call leftover from debugging.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -142,7 +142,6 @@ function gulpVartree(options) {
           file[options.prop] = curScope;
         } else {
           // Add a reference to the parent scope
-          console.log(file, file.metas);
           if(options.parentProp) {
             file[options.prop][options.parentProp] = curScope;
           }


### PR DESCRIPTION
need to either remove this line, or make it listen to options.prop
